### PR TITLE
build(jsregexp): add jsregexp for LuaSnip configuration in example.lua

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -217,6 +217,9 @@ return {
   -- first: disable default <tab> and <s-tab> behavior in LuaSnip
   {
     "L3MON4D3/LuaSnip",
+    -- install jsregexp. This is technically optional, but is required for 1:1 parity with VSCode snippets.
+    -- Read more about the impacts of the need for jsregexp with LuaSnip [here](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#transformations)
+    build = "make install_jsregexp",
     keys = function()
       return {}
     end,


### PR DESCRIPTION
## What

Adds a make call to LuaSnip configuration to ensure jsregexp is installed.

## Why

LuaSnip works with VSCode snippets by default, however, it will not run variable transformations without `jsregexp`. This can cause confusing behavior and is a more sane default.

The key takeaway is this:

> If jsregexp is not available, transformations are replaced by a simple copy.

## References

[lamÂlÂg]: https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#transformations
[rdia]: https://www.reddit.com/r/neovim/comments/11bvp0v/comment/ja04qa8/?context=3
[jalsÂiÂlÂg]: https://github.com/L3MON4D3/LuaSnip/issues/791

- [jsregexp and lazy.nvim setup· Issue #791 · L3MON4D3/LuaSnip · GitHub][jalsÂiÂlÂg]
- [Do I have a bug in my configs for neovim and LuaSnip, or is this a bug with LuaSnip?][rdia]
- [LuaSnip and VSCode variable transformation behavior][lamÂlÂg]