### PR TITLE
remove help from ensure_installed list

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -142,7 +142,6 @@ return {
     opts = {
       ensure_installed = {
         "bash",
-        "help",
         "html",
         "javascript",
         "json",
@@ -168,8 +167,8 @@ return {
     opts = function(_, opts)
       -- add tsx and treesitter
       vim.list_extend(opts.ensure_installed, {
-          "tsx",
-          "typescript",
+        "tsx",
+        "typescript",
       })
     end,
   },


### PR DESCRIPTION
solves following error
```
Installation not possible: ...vim/lazy/nvim-treesitter/lua/nvim-treesitter/install.lua:86: Parser not available for language "help"
```