### PR TITLE
Ignore lazy-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ debug
 foo.*
 *.log
 data
+lazy-lock.json


### PR DESCRIPTION
So that it won't be marked as `?` when submoduled in `~/.config/nvim`.