### PR TITLE
Ignore lazyvim.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ debug
 foo.*
 *.log
 data
+/lazyvim.json


### PR DESCRIPTION
Entries in this file are host specific and should not be shared across installs