### PR TITLE
fix: .on_attach deprecated, replace with .lsp.on_attach

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -102,7 +102,7 @@ return {
     dependencies = {
       "jose-elias-alvarez/typescript.nvim",
       init = function()
-        require("lazyvim.util").on_attach(function(_, buffer)
+        require("lazyvim.util").lsp.on_attach(function(_, buffer)
           -- stylua: ignore
           vim.keymap.set( "n", "<leader>co", "TypescriptOrganizeImports", { buffer = buffer, desc = "Organize Imports" })
           vim.keymap.set("n", "<leader>cR", "TypescriptRenameFile", { desc = "Rename File", buffer = buffer })


### PR DESCRIPTION
The starter template uses a deprecated method from lazyvim.util. 

`require("lazyvim.util").on_attach` is now `require("lazyvim.util").lsp.on_attach`

This creates a warning for the user when loading into nvim when they enable the example.lua template.