### PR TITLE
Remove importing Extras from the example

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -132,8 +132,11 @@ return {
   },
 
   -- for typescript, LazyVim also includes extra specs to properly setup lspconfig,
-  -- treesitter, mason and typescript.nvim. So instead of the above, you can use:
-  { import = "lazyvim.plugins.extras.lang.typescript" },
+  -- treesitter, mason and typescript.nvim. So instead of the above, you can use
+  -- { import = "lazyvim.plugins.extras.lang.typescript" } in config/lazy.lua or
+  -- installing Extras with :LazyExtras. Do not import Extras from plugins/ folder
+  -- as it might lead to unintended consequences for configuration. See
+  -- https://github.com/LazyVim/LazyVim/issues/2567
 
   -- add more treesitter parsers
   {
@@ -191,12 +194,6 @@ return {
       }
     end,
   },
-
-  -- use mini.starter instead of alpha
-  { import = "lazyvim.plugins.extras.ui.mini-starter" },
-
-  -- add jsonls and schemastore packages, and setup treesitter for json, json5 and jsonc
-  { import = "lazyvim.plugins.extras.lang.json" },
 
   -- add any tools you want to have installed below
   {


### PR DESCRIPTION
Importing Extras from plugins/ folder can have consequences on the configuration of the plugin that's enabled in the Extras. lazy.nvim loads plugins alphabetically from plugins/ folder which can mean that some plugins will have configuration based on the order in which they are loaded. When configuration options are getting merged this has no effect. But when configuration option is supposed to get completely replaced this can be a problem. For more details see LazyVim/LazyVim/issues/2567.

Extras documentation recommends using :LazyExtras command or importing extras in config/lazy.lua. Example should be consistent with that recommendation.