### PR TITLE
Deperecated syntax in bootstrapping of LazyVim starter

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,5 +1,6 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
   -- bootstrap lazy.nvim
   -- stylua: ignore
   vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })


### PR DESCRIPTION
In the current state of the lazy.nvim repository, certain updates have been made. However, there remains an outdated reference to 'vim.loop' for the bootstrapping process of 'lazyvim' in this start repo for LazyVim, despite 'vim.loop' being deprecated. To rectify this, I suggest a minor alteration by replacing it with the following code snippet:

```lua
if not (vim.uv or vim.loop).fs_stat(lazypath) then
    -- bootstrap
do
```