### PR TITLE
fix: improve comment about extras loading in config

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -11,11 +11,6 @@ require("lazy").setup({
   spec = {
     -- add LazyVim and import its plugins
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    -- import any extras modules here. note that this method can cause issues,
-    -- and the recommended way is to use :LazyExtras
-    -- { import = "lazyvim.plugins.extras.lang.typescript" },
-    -- { import = "lazyvim.plugins.extras.lang.json" },
-    -- { import = "lazyvim.plugins.extras.ui.mini-animate" },
     -- import/override with your plugins
     { import = "plugins" },
   },

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -11,7 +11,8 @@ require("lazy").setup({
   spec = {
     -- add LazyVim and import its plugins
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    -- import any extras modules here
+    -- import any extras modules here. note that this method can cause issues,
+    -- and the recommended way is to use :LazyExtras
     -- { import = "lazyvim.plugins.extras.lang.typescript" },
     -- { import = "lazyvim.plugins.extras.lang.json" },
     -- { import = "lazyvim.plugins.extras.ui.mini-animate" },


### PR DESCRIPTION
Old user are used to importing extras in the config, and every new user see the starting template which give the possibilities to load extras via import in the config.

As discussed in https://github.com/LazyVim/LazyVim/issues/3626, this way of loading extras can cause a problem, and so I think we should at least clarify that.

For note, i think we should remove entirely this comment in the starter template, so users are not tempted so use it.