### PR TITLE
docs: fix `lualine` component example

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -157,7 +157,11 @@ return {
     "nvim-lualine/lualine.nvim",
     event = "VeryLazy",
     opts = function(_, opts)
-      table.insert(opts.sections.lualine_x, "😄")
+      table.insert(opts.sections.lualine_x, {
+        function()
+          return "😄"
+        end,
+      })
     end,
   },
 


### PR DESCRIPTION
As per https://github.com/LazyVim/LazyVim/issues/4544 it creates confusion to the users who are just trying out the example to try things out. Better to avoid such misinterpretations in the future.

I'm assuming this will also update the docs automatically as I can deduce from
https://github.com/LazyVim/lazyvim.github.io/blob/25af26046a30be110f0aa19c87ad2a1a1e53ce45/lua/build.lua#L369-L372?