### PR TITLE
Update plugin examples for Lazyvim 14.x

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -40,27 +40,14 @@ return {
     end,
   },
 
-  -- change some telescope options and a keymap to browse plugin files
+  -- change fzf-lua config to add icon support
   {
-    "nvim-telescope/telescope.nvim",
-    keys = {
-      -- add a keymap to browse plugin files
-      -- stylua: ignore
-      {
-        "<leader>fp",
-        function() require("telescope.builtin").find_files({ cwd = require("lazy.core.config").options.root }) end,
-        desc = "Find Plugin File",
-      },
-    },
-    -- change some options
-    opts = {
-      defaults = {
-        layout_strategy = "horizontal",
-        layout_config = { prompt_position = "top" },
-        sorting_strategy = "ascending",
-        winblend = 0,
-      },
-    },
+    "ibhagwan/fzf-lua",
+    -- optional for icon support
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    -- or if using mini.icons/mini.nvim
+    -- dependencies = { "echasnovski/mini.icons" },
+    opts = {},
   },
 
   -- add pyright to lspconfig


### PR DESCRIPTION
`fzf-lua` has replaced telescope and is now default.

- Updated examples with relevant `fzf-lua` config