### PR TITLE
docs(example): remove `import` entries as they confuse new users

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -111,10 +111,6 @@ return {
     },
   },
 
-  -- for typescript, LazyVim also includes extra specs to properly setup lspconfig,
-  -- treesitter, mason and typescript.nvim. So instead of the above, you can use:
-  { import = "lazyvim.plugins.extras.lang.typescript" },
-
   -- add more treesitter parsers
   {
     "nvim-treesitter/nvim-treesitter",
@@ -175,12 +171,6 @@ return {
       }
     end,
   },
-
-  -- use mini.starter instead of alpha
-  { import = "lazyvim.plugins.extras.ui.mini-starter" },
-
-  -- add jsonls and schemastore packages, and setup treesitter for json, json5 and jsonc
-  { import = "lazyvim.plugins.extras.lang.json" },
 
   -- add any tools you want to have installed below
   {


### PR DESCRIPTION
Fixes https://github.com/LazyVim/LazyVim/issues/5854. Would be good to not mention `import` entries in `example.lua`, so that the LazyVim website docs don't mention them as they confuse new users, especially with the new warning about "wrong order".